### PR TITLE
Add param to configure the currency symbol

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -6,6 +6,7 @@ theme = "agnes-hugo-theme"
 [params]
 	dateFormat = "Jan 2, 2023" 
 	authorName = "Ported to Hugo by Debashish"
+	currencySymbol = "$"
 	google_analytics_id = "GA-"
 	
 [menu]

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -104,7 +104,7 @@
                                     <div class="pricing-table-main">
                                         <div class="pricing-table-header is-revealing">
                                             <div class="pricing-table-title mt-12 mb-8">{{ .PricingTitle }}</div>
-                                            <div class="pricing-table-price mb-32 pb-24"><span class="pricing-table-price-currency h4">$</span><span class="pricing-table-price-amount h2">{{ .PricingRate }}</span>/mo</div>
+					    <div class="pricing-table-price mb-32 pb-24"><span class="pricing-table-price-currency h4">{{ site.Params.currencySymbol }}</span><span class="pricing-table-price-amount h2">{{ .PricingRate }}</span>/mo</div>
                                         </div>
                                         <ul class="pricing-table-features list-reset text-xs mt-24 mb-56">
 											{{ range .Features }}

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -104,7 +104,7 @@
                                     <div class="pricing-table-main">
                                         <div class="pricing-table-header is-revealing">
                                             <div class="pricing-table-title mt-12 mb-8">{{ .PricingTitle }}</div>
-					    <div class="pricing-table-price mb-32 pb-24"><span class="pricing-table-price-currency h4">{{ site.Params.currencySymbol }}</span><span class="pricing-table-price-amount h2">{{ .PricingRate }}</span>/mo</div>
+                                            <div class="pricing-table-price mb-32 pb-24"><span class="pricing-table-price-currency h4">{{ site.Params.currencySymbol }}</span><span class="pricing-table-price-amount h2">{{ .PricingRate }}</span>/mo</div>
                                         </div>
                                         <ul class="pricing-table-features list-reset text-xs mt-24 mb-56">
 											{{ range .Features }}


### PR DESCRIPTION
For example, to edit the currency from $ to £, one would just set `params.currencySymbol` to "£".

See below for render.

<img width="1096" alt="image" src="https://github.com/dchucks/agnes-hugo-theme/assets/17353640/fda6cb2c-a19b-4edc-a529-90426f5f3c5e">
